### PR TITLE
Apply Tahadi brand theme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: netlify/actions/cli@master
+        with:
+          args: deploy --prod
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint

--- a/index.html
+++ b/index.html
@@ -2,9 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="/tahadialthalatheen/images/favicon.ico"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>تحدي الثلاثين</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'DG Bebo';
+  src: url('/tahadialthalatheen/fonts/DG-BeboT.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Almarai';
+  src: url('/tahadialthalatheen/fonts/Almarai-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+
 body {
-  font-family: 'Noto Naskh Arabic', Tajawal, Arial, sans-serif;
-  background: #070718;
+  @apply bg-brand-dark text-brand-light font-body;
 }
 .font-arabic {
   font-family: 'Noto Naskh Arabic', Tajawal, Arial, sans-serif;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -9,6 +9,12 @@ import { Link } from 'react-router-dom';
 export default function Landing() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center space-y-6 p-4">
+      {/* Logo from public assets to match the new branding */}
+      <img
+        src="/tahadialthalatheen/images/Logo.png"
+        alt="تحدي الثلاثين"
+        className="w-32 md:w-48"
+      />
       <h1 className="text-4xl font-extrabold text-accent">تحدي الثلاثين</h1>
       <p className="text-center text-lg text-gray-300">
         ابدأ التحدي مع أصدقائك الآن!

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,9 +8,15 @@ module.exports = {
         accent: '#6a5acd', // violet
         accent2: '#38bdf8', // blue
         glass: 'rgba(30,32,60,0.8)',
+        'brand-dark': '#19194d',
+        'brand-grad': '#6e45e2',
+        'brand-light': '#efefef',
+        'accent-blue': '#50aaf2',
       },
       fontFamily: {
         arabic: ['"Noto Naskh Arabic"', 'Tajawal', 'Arial', 'sans-serif'],
+        header: ['DG Bebo', 'sans-serif'],
+        body: ['Almarai', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Tahadi color palette and fonts to Tailwind
- include DG Bebo and Almarai fonts with @font-face
- style body with brand colors
- show site logo on landing page
- update favicon and page title
- add dedicated lint and deploy workflows

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68894e995668833087be11fd412287c8