### PR TITLE
Restore quiz pages and lobby

### DIFF
--- a/full-dependency-map.json
+++ b/full-dependency-map.json
@@ -3,14 +3,7 @@
   "netlify/functions/create-daily-token.ts": [],
   "netlify/functions/delete-daily-room.ts": [],
   "netlify/functions/game-event.ts": [],
-  "src/App.tsx": [
-    "src/components/ConnectionBanner.tsx",
-    "src/context/GameContext.tsx",
-    "src/pages/Join.tsx",
-    "src/pages/Landing.tsx",
-    "src/pages/NotFound.tsx",
-    "src/pages/TestAPI.tsx"
-  ],
+  "src/App.tsx": [],
   "src/components/Buzzer.tsx": [
     "src/hooks/useGame.ts"
   ],
@@ -50,12 +43,18 @@
     "src/App.tsx",
     "src/index.css"
   ],
+  "src/pages/FinalScores.tsx": [],
   "src/pages/Join.tsx": [],
   "src/pages/Landing.tsx": [],
+  "src/pages/Lobby.tsx": [],
   "src/pages/NotFound.tsx": [],
+  "src/pages/QuizRoom.tsx": [],
+  "src/pages/Scoreboard.tsx": [],
+  "src/pages/SegmentIntro.tsx": [],
   "src/pages/TestAPI.tsx": [
     "src/lib/supabaseClient.ts"
   ],
+  "src/themes/clubs.ts": [],
   "src/types/game.ts": [],
   "src/utils/teamUtils.ts": [],
   "src/vite-env.d.ts": []

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { Routes, Route } from 'react-router-dom';
-import { GameProvider } from './context/GameContext';
-import ConnectionBanner from './components/ConnectionBanner';
+import { GameProvider } from '@/context/GameContext';
+import ConnectionBanner from '@/components/ConnectionBanner';
 
 // Only import the minimal set of pages needed for this test branch.
-import Landing from './pages/Landing';
-import Join from './pages/Join';
-import TestAPI from './pages/TestAPI';
-import NotFound from './pages/NotFound';
+import Landing from '@/pages/Landing';
+import Join from '@/pages/Join';
+import Lobby from '@/pages/Lobby';
+import QuizRoom from '@/pages/QuizRoom';
+import FinalScores from '@/pages/FinalScores';
+import NotFound from '@/pages/NotFound';
 
 /**
  * Root application component.  The `Test_arena` branch aims to focus on
@@ -22,7 +24,9 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/join" element={<Join />} />
-          <Route path="/test-api" element={<TestAPI />} />
+          <Route path="/lobby" element={<Lobby />} />
+          <Route path="/quiz" element={<QuizRoom />} />
+          <Route path="/scores" element={<FinalScores />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/src/pages/FinalScores.tsx
+++ b/src/pages/FinalScores.tsx
@@ -1,0 +1,3 @@
+export default function FinalScores() {
+  return null;
+}

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,49 +1,287 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { getAllTeams, searchTeams, searchFlags } from '@/utils/teamUtils';
+import { GameDatabase } from '@/lib/gameDatabase';
 
-/**
- * Join page allowing a user to enter their name and a room ID.  In the
- * simplified Test_arena branch joining a room does not start any game
- * logic; instead it simply navigates the user to `/test-api` where
- * the netlify functions can be exercised.
- */
 export default function Join() {
-  const [name, setName] = useState('');
-  const [room, setRoom] = useState('');
   const navigate = useNavigate();
+  const [step, setStep] = useState(1);
+  const [joinType, setJoinType] = useState<'host' | 'player' | ''>('');
+  const [gameId, setGameId] = useState('');
+  const [name, setName] = useState('');
+  const [selectedFlag, setSelectedFlag] = useState('');
+  const [selectedTeam, setSelectedTeam] = useState('');
+  const [flagSearch, setFlagSearch] = useState('');
+  const [teamSearch, setTeamSearch] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const allTeams = getAllTeams();
+  const filteredFlags = searchFlags(flagSearch);
+  const filteredTeams = searchTeams(allTeams, teamSearch);
+
+  const handleJoinTypeSelect = (type: 'host' | 'player') => {
+    setJoinType(type);
+    setStep(2);
+  };
+
+  const handleGameIdSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // For demonstration simply navigate to the test page; in a full
-    // implementation you would call an API to join the room.
-    navigate('/test-api');
+    setErrorMsg('');
+    if (!gameId.trim()) return;
+
+    const actualGameId = gameId.toUpperCase().replace('-HOST', '');
+    const existing = await GameDatabase.getGame(actualGameId);
+    if (!existing) {
+      setErrorMsg('لا توجد جلسة بهذا الرمز');
+      return;
+    }
+
+    if (joinType === 'host') {
+      navigate(`/lobby/${actualGameId}?role=host-mobile`);
+    } else {
+      setStep(3);
+    }
+  };
+
+  const handlePlayerJoin = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim() && selectedFlag && selectedTeam) {
+      const playerRole = 'playerA'; // You might want to make this dynamic based on available slots
+      navigate(
+        `/lobby/${gameId.toUpperCase()}?role=${playerRole}&name=${encodeURIComponent(name)}&flag=${selectedFlag}&club=${selectedTeam}&autoJoin=true`,
+      );
+    }
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-4">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <h2 className="text-2xl font-bold">Join a Game</h2>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Your Name"
-          className="w-full rounded border p-2"
-        />
-        <input
-          type="text"
-          value={room}
-          onChange={(e) => setRoom(e.target.value)}
-          placeholder="Room ID"
-          className="w-full rounded border p-2"
-        />
-        <button
-          type="submit"
-          className="w-full rounded bg-blue-600 p-2 text-white"
-        >
-          Join Room
-        </button>
-      </form>
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 flex items-center justify-center p-4">
+      <motion.div
+        className="bg-white/10 backdrop-blur-sm rounded-3xl p-8 w-full max-w-md"
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-white mb-2 font-arabic">
+            انضم للعبة
+          </h1>
+          <p className="text-white/70 font-arabic">
+            {step === 1
+              ? 'اختر نوع الانضمام'
+              : step === 2
+                ? 'أدخل رمز اللعبة والاسم'
+                : 'اختر العلم والفريق'}
+          </p>
+        </div>
+
+        {step === 1 ? (
+          // Step 1: Choose join type
+          <div className="space-y-4">
+            <motion.button
+              onClick={() => handleJoinTypeSelect('host')}
+              className="w-full p-6 bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/50 rounded-2xl text-white transition-all"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <div className="text-center">
+                <div className="text-3xl mb-2">🎤</div>
+                <h3 className="text-lg font-bold font-arabic mb-2">
+                  انضم كمقدم
+                </h3>
+                <p className="text-sm text-blue-200 font-arabic">
+                  للمقدمين الذين يريدون المشاركة بالفيديو من الهاتف
+                </p>
+                <p className="text-xs text-blue-300 font-arabic mt-1">
+                  تحتاج رمز المقدم (GAME-HOST)
+                </p>
+              </div>
+            </motion.button>
+
+            <motion.button
+              onClick={() => handleJoinTypeSelect('player')}
+              className="w-full p-6 bg-green-500/20 hover:bg-green-500/30 border border-green-500/50 rounded-2xl text-white transition-all"
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <div className="text-center">
+                <div className="text-3xl mb-2">🎮</div>
+                <h3 className="text-lg font-bold font-arabic mb-2">
+                  انضم كلاعب
+                </h3>
+                <p className="text-sm text-green-200 font-arabic">
+                  للاعبين المشاركين في المسابقة
+                </p>
+                <p className="text-xs text-green-300 font-arabic mt-1">
+                  تحتاج رمز اللعبة العادي
+                </p>
+              </div>
+            </motion.button>
+
+            <button
+              onClick={() => navigate('/')}
+              className="w-full mt-4 px-4 py-2 text-white/70 hover:text-white font-arabic transition-colors"
+            >
+              العودة للرئيسية
+            </button>
+          </div>
+        ) : step === 2 ? (
+          // Step 2: Game ID and Name
+          <form onSubmit={handleGameIdSubmit} className="space-y-6">
+            <div>
+              <label className="block text-white/80 mb-2 font-arabic">
+                {joinType === 'host' ? 'رمز المقدم' : 'رمز اللعبة'}
+              </label>
+              <input
+                type="text"
+                value={gameId}
+                onChange={(e) => setGameId(e.target.value.toUpperCase())}
+                placeholder={
+                  joinType === 'host' ? 'مثال: ABC123-HOST' : 'مثال: ABC123'
+                }
+                className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white placeholder-white/50 focus:outline-none focus:border-accent2 font-mono text-center text-lg"
+                required
+              />
+              {joinType === 'host' && (
+                <p className="text-xs text-blue-300 mt-1 font-arabic text-center">
+                  ستجد رمز المقدم في صفحة إعداد الجلسة
+                </p>
+              )}
+              {errorMsg && (
+                <p className="text-xs text-red-400 mt-1 font-arabic text-center">
+                  {errorMsg}
+                </p>
+              )}
+            </div>
+
+            {joinType === 'player' && (
+              <div>
+                <label className="block text-white/80 mb-2 font-arabic">
+                  الاسم
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="أدخل اسمك"
+                  className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white placeholder-white/50 focus:outline-none focus:border-accent2 font-arabic text-center"
+                  required
+                />
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setStep(1)}
+                className="flex-1 px-4 py-3 bg-gray-600 hover:bg-gray-700 text-white rounded-xl font-arabic transition-colors"
+              >
+                رجوع
+              </button>
+              <button
+                type="submit"
+                disabled={
+                  !gameId.trim() || (joinType === 'player' && !name.trim())
+                }
+                className="flex-1 px-4 py-3 bg-accent2 hover:bg-accent text-white rounded-xl font-arabic transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {joinType === 'host' ? 'انضم كمقدم' : 'التالي'}
+              </button>
+            </div>
+          </form>
+        ) : (
+          // Step 3: Flag and Team Selection (for players only)
+          <form onSubmit={handlePlayerJoin} className="space-y-6">
+            {/* Flag Selection */}
+            <div>
+              <label className="block text-white/80 mb-2 font-arabic">
+                اختر العلم
+              </label>
+              <input
+                type="text"
+                value={flagSearch}
+                onChange={(e) => setFlagSearch(e.target.value)}
+                placeholder="ابحث عن بلد..."
+                className="w-full px-4 py-2 mb-3 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/50 focus:outline-none focus:border-accent2 font-arabic"
+              />
+              <div className="grid grid-cols-4 gap-2 max-h-32 overflow-y-auto">
+                {filteredFlags.map((flag) => (
+                  <button
+                    key={flag.code}
+                    type="button"
+                    onClick={() => setSelectedFlag(flag.code)}
+                    className={`p-2 rounded-lg border-2 transition-all ${
+                      selectedFlag === flag.code
+                        ? 'border-accent2 bg-accent2/20'
+                        : 'border-white/20 bg-white/5 hover:border-white/40'
+                    }`}
+                  >
+                    <span className={`fi fi-${flag.code} text-2xl`}></span>
+                    <p className="text-xs text-white/80 mt-1 font-arabic">
+                      {flag.name}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Team Selection */}
+            <div>
+              <label className="block text-white/80 mb-2 font-arabic">
+                اختر الفريق
+              </label>
+              <input
+                type="text"
+                value={teamSearch}
+                onChange={(e) => setTeamSearch(e.target.value)}
+                placeholder="ابحث عن فريق..."
+                className="w-full px-4 py-2 mb-3 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/50 focus:outline-none focus:border-accent2 font-arabic"
+              />
+              <div className="grid grid-cols-2 gap-2 max-h-40 overflow-y-auto">
+                {filteredTeams.map((team) => (
+                  <button
+                    key={team.name}
+                    type="button"
+                    onClick={() => setSelectedTeam(team.name)}
+                    className={`p-3 rounded-lg border-2 transition-all flex items-center gap-2 ${
+                      selectedTeam === team.name
+                        ? 'border-accent2 bg-accent2/20'
+                        : 'border-white/20 bg-white/5 hover:border-white/40'
+                    }`}
+                  >
+                    <img
+                      src={team.logoPath}
+                      alt={team.name}
+                      className="w-8 h-8 object-contain"
+                      loading="lazy"
+                    />
+                    <span className="text-white font-arabic text-sm">
+                      {team.displayName}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setStep(2)}
+                className="flex-1 px-4 py-3 bg-gray-600 hover:bg-gray-700 text-white rounded-xl font-arabic transition-colors"
+              >
+                رجوع
+              </button>
+              <button
+                type="submit"
+                disabled={!selectedFlag || !selectedTeam}
+                className="flex-1 px-4 py-3 bg-green-600 hover:bg-green-700 text-white rounded-xl font-arabic transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                انضم للعبة
+              </button>
+            </div>
+          </form>
+        )}
+      </motion.div>
     </div>
   );
 }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,38 +1,140 @@
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { useGame } from '@/hooks/useGame';
+import { useState } from 'react';
 
-/**
- * Minimal landing page for the Test_arena branch.  Offers links to
- * start a new test session or join an existing one.  The styling
- * aligns loosely with the original project without including any
- * heavy design dependencies.
- */
 export default function Landing() {
+  const navigate = useNavigate();
+  const { actions } = useGame();
+  const [isCreating, setIsCreating] = useState(false);
+  const [customGameId, setCustomGameId] = useState('');
+  const [useCustomId, setUseCustomId] = useState(false);
+
+  const handleCreateSession = async () => {
+    setIsCreating(true);
+    try {
+      // Use custom game ID or generate a random one
+      const gameId =
+        useCustomId && customGameId.trim()
+          ? customGameId.trim().toUpperCase()
+          : Math.random().toString(36).substring(2, 8).toUpperCase();
+
+      // Initialize the game
+      actions.startGame(gameId);
+
+      // Navigate to host setup page
+      navigate(`/host-setup/${gameId}`, { replace: true });
+    } catch (error) {
+      console.error('Failed to start session:', error);
+      setIsCreating(false);
+    }
+  };
+
+  const handleJoinGame = () => {
+    navigate('/join');
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center space-y-6 p-4">
-      {/* Logo from public assets to match the new branding */}
-      <img
-        src="/tahadialthalatheen/images/Logo.png"
-        alt="تحدي الثلاثين"
-        className="w-32 md:w-48"
-      />
-      <h1 className="text-4xl font-extrabold text-accent">تحدي الثلاثين</h1>
-      <p className="text-center text-lg text-gray-300">
-        ابدأ التحدي مع أصدقائك الآن!
-      </p>
-      <div className="space-y-3">
-        <Link
-          to="/join"
-          className="block rounded bg-blue-600 px-6 py-3 text-center text-white hover:bg-blue-700"
+    <motion.div
+      className="flex flex-col items-center justify-center min-h-screen px-4"
+      initial={{ opacity: 0, scale: 0.96 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.96 }}
+    >
+      <motion.h1
+        className="text-5xl sm:text-7xl font-extrabold mb-6 text-accent glow font-arabic text-center"
+        style={{
+          textShadow: '0 0 30px #7c3aed, 0 0 20px #38bdf8',
+        }}
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.2 }}
+      >
+        تحدي الثلاثين
+      </motion.h1>
+
+      <motion.p
+        className="mb-10 text-accent2 text-lg font-arabic text-center"
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.4 }}
+      >
+        !ابدأ التحدي مع أصدقائك الآن
+      </motion.p>
+
+      <motion.div
+        className="flex flex-col gap-6 items-center w-full max-w-md"
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.6 }}
+      >
+        {/* Custom Game ID Option */}
+        <div className="w-full">
+          <label className="flex items-center gap-2 text-white/80 text-sm font-arabic mb-3">
+            <input
+              type="checkbox"
+              checked={useCustomId}
+              onChange={(e) => setUseCustomId(e.target.checked)}
+              className="rounded"
+            />
+            استخدام رمز جلسة مخصص
+          </label>
+
+          {useCustomId && (
+            <motion.input
+              type="text"
+              value={customGameId}
+              onChange={(e) =>
+                setCustomGameId(
+                  e.target.value.replace(/[^A-Za-z0-9]/g, '').substring(0, 8),
+                )
+              }
+              placeholder="ادخل رمز الجلسة (حروف وأرقام فقط)"
+              className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 font-mono text-center uppercase"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              maxLength={8}
+            />
+          )}
+        </div>
+
+        <button
+          onClick={handleCreateSession}
+          disabled={isCreating || (useCustomId && !customGameId.trim())}
+          className="w-full px-10 py-4 text-xl rounded-2xl font-bold bg-accent2 hover:bg-accent shadow-lg transition-all border border-accent glow disabled:opacity-50 disabled:cursor-not-allowed font-arabic"
         >
-          الانضمام إلى جلسة
-        </Link>
-        <Link
-          to="/test-api"
-          className="block rounded bg-green-600 px-6 py-3 text-center text-white hover:bg-green-700"
+          {isCreating ? (
+            <div className="flex items-center justify-center gap-2">
+              <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+              إنشاء الجلسة...
+            </div>
+          ) : (
+            'إنشاء جلسة جديدة'
+          )}
+        </button>
+
+        <button
+          onClick={handleJoinGame}
+          className="w-full px-6 py-3 text-lg rounded-xl font-bold bg-transparent hover:bg-white/10 text-white/80 hover:text-accent2 border border-white/20 hover:border-accent2 transition-all font-arabic"
         >
-          تجربة الواجهة البرمجية
-        </Link>
-      </div>
-    </div>
+          الانضمام لجلسة
+        </button>
+      </motion.div>
+
+      {/* Instructions */}
+      <motion.div
+        className="mt-12 text-center text-white/60 text-sm max-w-md"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1 }}
+      >
+        <p className="font-arabic">
+          إنشاء جلسة جديدة: ستصبح المقدم وتتحكم في اللعبة
+        </p>
+        <p className="font-arabic mt-1">
+          الانضمام لجلسة: ادخل كلاعب في جلسة موجودة
+        </p>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -1,0 +1,446 @@
+import { useEffect, useState } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { useGame } from '@/hooks/useGame';
+import VideoRoom from '@/components/VideoRoom';
+import { CLUB_THEMES } from '@/themes/clubs';
+
+interface LobbyParticipant {
+  id: string;
+  name: string;
+  type: 'host-pc' | 'host-mobile' | 'player';
+  playerId?: 'playerA' | 'playerB';
+  flag?: string;
+  club?: string;
+  isConnected: boolean;
+}
+
+export default function TrueLobby() {
+  const { gameId } = useParams<{ gameId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { state, actions } = useGame();
+
+  const [myParticipant, setMyParticipant] = useState<LobbyParticipant | null>(
+    null,
+  );
+  const [isCreatingRoom, setIsCreatingRoom] = useState(false);
+
+  // Automatically create the video room when the host PC opens the lobby
+  useEffect(() => {
+    if (
+      myParticipant?.type === 'host-pc' &&
+      !state.videoRoomCreated &&
+      gameId
+    ) {
+      setIsCreatingRoom(true);
+      actions.createVideoRoom(gameId).finally(() => setIsCreatingRoom(false));
+    }
+  }, [myParticipant, state.videoRoomCreated, gameId, actions]);
+
+  // Use global video room state
+  const videoRoomCreated = state.videoRoomCreated || false;
+
+  // Initialize game and determine my role
+  useEffect(() => {
+    if (!gameId) return;
+
+    // Initialize game if needed
+    if (state.gameId !== gameId) {
+      actions.startGame(gameId);
+    }
+
+    // Determine my role from URL parameters
+    const role = searchParams.get('role');
+    const name = searchParams.get('name');
+    const flag = searchParams.get('flag');
+    const club = searchParams.get('club');
+    const hostName = searchParams.get('hostName');
+    const autoJoin = searchParams.get('autoJoin') === 'true';
+
+    let participant: LobbyParticipant | null = null;
+
+    if (role === 'host') {
+      // PC Host (control only)
+      participant = {
+        id: 'host-pc',
+        name: hostName || state.hostName || 'المقدم',
+        type: 'host-pc',
+        isConnected: true,
+      };
+      if (hostName) actions.updateHostName(hostName);
+    } else if (role === 'host-mobile') {
+      // Mobile Host (with video)
+      participant = {
+        id: 'host-mobile',
+        name: name || state.hostName || 'المقدم',
+        type: 'host-mobile',
+        isConnected: true,
+      };
+      if (name) actions.updateHostName(name);
+    } else if (
+      (role === 'playerA' || role === 'playerB') &&
+      name &&
+      flag &&
+      club
+    ) {
+      // Player
+      participant = {
+        id: role,
+        name,
+        type: 'player',
+        playerId: role,
+        flag,
+        club,
+        isConnected: true,
+      };
+
+      if (autoJoin) {
+        actions.joinGame(role, {
+          name,
+          flag,
+          club,
+          isConnected: true,
+        });
+      }
+    }
+
+    setMyParticipant(participant);
+
+    // Track presence for real-time synchronization
+    if (participant) {
+      actions.trackPresence(participant);
+    }
+  }, [gameId, searchParams, state.gameId, state.hostName, actions]);
+
+  // Create video room when host PC clicks button
+  const handleCreateVideoRoom = async () => {
+    if (!gameId) return;
+
+    setIsCreatingRoom(true);
+    try {
+      const result = await actions.createVideoRoom(gameId);
+      if (!result.success) {
+        console.error('Failed to create room:', result.error);
+        alert('فشل في إنشاء غرفة الفيديو: ' + result.error);
+      }
+    } catch (error) {
+      console.error('Error creating room:', error);
+      alert('خطأ في إنشاء غرفة الفيديو');
+    } finally {
+      setIsCreatingRoom(false);
+    }
+  };
+
+  const handleEndVideoRoom = async () => {
+    if (!gameId) return;
+
+    try {
+      await actions.endVideoRoom(gameId);
+    } catch (error) {
+      console.error('Error ending room:', error);
+      alert('خطأ في إنهاء غرفة الفيديو');
+    }
+  };
+
+  const handleStartGame = () => {
+    navigate(`/game/${gameId}?role=host`);
+  };
+
+  if (!myParticipant || !gameId) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 flex items-center justify-center">
+        <div className="text-white text-center font-arabic">
+          جاري تحميل الصالة...
+        </div>
+      </div>
+    );
+  }
+
+  const connectedPlayers = Object.values(state.players).filter(
+    (p) => p.isConnected,
+  ).length;
+  const hostMobileConnected = myParticipant.type === 'host-mobile' || false; // TODO: Track this in global state
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 p-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Header - Same for everyone */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2 font-arabic">
+            صالة الانتظار
+          </h1>
+          <div className="space-y-2">
+            <p className="text-accent2 font-arabic">
+              رمز الجلسة: <span className="font-mono text-2xl">{gameId}</span>
+            </p>
+            <p className="text-white/70 font-arabic">
+              اللاعبون المتصلون: {connectedPlayers}/2
+            </p>
+          </div>
+        </div>
+
+        {/* Host PC Controls */}
+        {myParticipant.type === 'host-pc' && (
+          <div className="mb-8 bg-blue-500/20 rounded-xl p-6 border border-blue-500/30">
+            <h3 className="text-xl font-bold text-blue-300 mb-4 font-arabic text-center">
+              تحكم المقدم
+            </h3>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+              <div>
+                <p className="text-white font-arabic mb-2">إعدادات الأسئلة:</p>
+                <div className="text-sm text-white/70 font-arabic space-y-1">
+                  {Object.entries(state.segments).map(
+                    ([segmentCode, segment]) => (
+                      <div key={segmentCode} className="flex justify-between">
+                        <span>{segmentCode}:</span>
+                        <span>{segment.questionsPerSegment} سؤال</span>
+                      </div>
+                    ),
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <p className="text-white font-arabic mb-2">رموز الانضمام:</p>
+                <div className="text-sm text-white/70 font-arabic space-y-1">
+                  <p>
+                    رمز المقدم (للهاتف):{' '}
+                    <span className="font-mono text-blue-300">
+                      {gameId}-HOST
+                    </span>
+                  </p>
+                  <p>
+                    رمز اللاعبين:{' '}
+                    <span className="font-mono text-blue-300">{gameId}</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              {!videoRoomCreated ? (
+                <button
+                  onClick={handleCreateVideoRoom}
+                  disabled={isCreatingRoom}
+                  className="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg font-arabic transition-colors"
+                >
+                  {isCreatingRoom
+                    ? 'جاري إنشاء غرفة الفيديو...'
+                    : 'إنشاء غرفة الفيديو'}
+                </button>
+              ) : (
+                <>
+                  <div className="px-6 py-3 bg-green-600 text-white rounded-lg font-arabic">
+                    ✓ غرفة الفيديو جاهزة
+                  </div>
+                  <button
+                    onClick={handleEndVideoRoom}
+                    className="px-6 py-3 bg-red-600 hover:bg-red-700 text-white rounded-lg font-arabic transition-colors"
+                  >
+                    إنهاء غرفة الفيديو
+                  </button>
+                </>
+              )}
+
+              <button
+                onClick={handleStartGame}
+                disabled={connectedPlayers < 2 || !videoRoomCreated}
+                className="px-6 py-3 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg font-arabic transition-colors"
+              >
+                {connectedPlayers < 2 ? 'في انتظار اللاعبين...' : 'بدء اللعبة'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Unified Video Grid - Same for everyone */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+          {/* Host Mobile Video */}
+          <div className="bg-gradient-to-br from-blue-800/30 to-purple-800/30 rounded-xl p-6 border border-blue-500/30">
+            <h3 className="text-xl font-bold text-blue-300 mb-4 font-arabic text-center">
+              المقدم {myParticipant.type === 'host-mobile' && '(أنت)'}
+            </h3>
+
+            <div className="aspect-video bg-black/30 rounded-lg mb-4 overflow-hidden">
+              {videoRoomCreated && myParticipant.type === 'host-mobile' ? (
+                <VideoRoom
+                  gameId={gameId}
+                  userName={state.hostName}
+                  userRole="host-mobile"
+                  className="w-full h-full"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <div className="text-center text-white/50">
+                    <div className="text-4xl mb-2">📱</div>
+                    <p className="text-sm font-arabic">
+                      {!videoRoomCreated
+                        ? myParticipant.type === 'host-pc'
+                          ? 'اضغط "إنشاء غرفة الفيديو" أولاً'
+                          : 'في انتظار إنشاء الغرفة...'
+                        : myParticipant.type === 'host-pc'
+                          ? 'انضم من هاتفك للفيديو'
+                          : 'في انتظار المقدم...'}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="text-center">
+              <p className="text-white font-arabic text-lg">{state.hostName}</p>
+              <div className="flex items-center justify-center gap-2 mt-2">
+                <div
+                  className={`w-3 h-3 rounded-full ${
+                    hostMobileConnected ? 'bg-green-500' : 'bg-gray-500'
+                  }`}
+                />
+                <span className="text-white/70 text-sm font-arabic">
+                  {hostMobileConnected ? 'متصل' : 'غير متصل'}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Player A Video */}
+          {(['playerA', 'playerB'] as const).map((playerId, index) => {
+            const player = state.players[playerId];
+            const isMe =
+              myParticipant.type === 'player' &&
+              myParticipant.playerId === playerId;
+            const clubTheme =
+              CLUB_THEMES[player.club as keyof typeof CLUB_THEMES] ||
+              CLUB_THEMES.liverpool;
+
+            return (
+              <div
+                key={playerId}
+                className={`bg-gradient-to-br rounded-xl p-6 border ${
+                  isMe
+                    ? 'from-green-800/40 to-blue-800/40 border-green-500/50'
+                    : 'from-gray-800/30 to-gray-700/30 border-gray-500/30'
+                }`}
+              >
+                <h3
+                  className="text-xl font-bold text-center mb-4 font-arabic"
+                  style={{ color: clubTheme.primary }}
+                >
+                  لاعب {index + 1} {isMe && '(أنت)'}
+                </h3>
+
+                <div className="aspect-video bg-black/30 rounded-lg mb-4 overflow-hidden">
+                  {player.isConnected && videoRoomCreated && isMe ? (
+                    <VideoRoom
+                      gameId={gameId}
+                      userName={player.name}
+                      userRole={playerId}
+                      className="w-full h-full"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center">
+                      <div className="text-center text-white/50">
+                        <div className="text-4xl mb-2">👤</div>
+                        <p className="text-sm font-arabic">
+                          {!player.isConnected
+                            ? 'في انتظار الاتصال...'
+                            : !videoRoomCreated
+                              ? 'في انتظار إنشاء الغرفة...'
+                              : !isMe
+                                ? 'فيديو اللاعب الآخر'
+                                : 'في انتظار الفيديو...'}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {player.isConnected ? (
+                  <div className="text-center space-y-2">
+                    <div className="flex items-center justify-center gap-2">
+                      <span
+                        className={`fi fi-${player.flag} w-6 h-4 rounded`}
+                      ></span>
+                      <p className="text-white font-arabic text-lg">
+                        {player.name}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center justify-center gap-2">
+                      <img
+                        src={`/src/assets/logos/${player.club}.svg`}
+                        alt={player.club}
+                        className="w-6 h-6"
+                        loading="lazy"
+                      />
+                      <p className="text-white/70 text-sm font-arabic capitalize">
+                        {player.club?.replace('-', ' ')}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center justify-center gap-2">
+                      <div className="w-3 h-3 rounded-full bg-green-500" />
+                      <span className="text-green-400 text-sm font-arabic">
+                        متصل
+                      </span>
+                    </div>
+
+                    <div className="text-white/60 text-sm font-arabic">
+                      النقاط: {player.score} | الأخطاء: {player.strikes}/3
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center">
+                    <p className="text-white/50 font-arabic">لم ينضم بعد</p>
+                    <div className="flex items-center justify-center gap-2 mt-2">
+                      <div className="w-3 h-3 rounded-full bg-gray-500" />
+                      <span className="text-gray-400 text-sm font-arabic">
+                        غير متصل
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Instructions */}
+        <motion.div
+          className="text-center text-white/60 text-sm max-w-2xl mx-auto"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+        >
+          <div className="bg-blue-500/10 rounded-lg p-4 border border-blue-500/20">
+            <p className="font-arabic mb-2">💡 تعليمات:</p>
+            <div className="text-right space-y-1 font-arabic">
+              {myParticipant.type === 'host-pc' && (
+                <>
+                  <p>• هذا الجهاز للتحكم في اللعبة فقط</p>
+                  <p>• اضغط "إنشاء غرفة الفيديو" لبدء الفيديو</p>
+                  <p>• للمشاركة بالفيديو، انضم من هاتفك برمز: {gameId}-HOST</p>
+                  <p>• انتظر انضمام اللاعبين ثم اضغط "بدء اللعبة"</p>
+                </>
+              )}
+              {myParticipant.type === 'host-mobile' && (
+                <>
+                  <p>• أنت متصل كمقدم بالفيديو</p>
+                  <p>• يمكنك رؤية جميع المشاركين في نفس الصفحة</p>
+                </>
+              )}
+              {myParticipant.type === 'player' && (
+                <>
+                  <p>• أنت متصل كلاعب</p>
+                  <p>• انتظر إنشاء غرفة الفيديو من المقدم</p>
+                  <p>• انتظر بدء اللعبة من المقدم</p>
+                </>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/QuizRoom.tsx
+++ b/src/pages/QuizRoom.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { useGame } from '@/hooks/useGame';
+import { getQuestionsForSegment } from '@/data/questions';
+import Buzzer from '@/components/Buzzer';
+import Scoreboard from '@/components/Scoreboard';
+import Timer from '@/components/Timer';
+
+type UserRole = 'host' | 'playerA' | 'playerB';
+
+export default function QuizRoom() {
+  const { gameId } = useParams<{ gameId: string }>();
+  const [searchParams] = useSearchParams();
+  const { state, actions } = useGame();
+
+  const userRole = (searchParams.get('role') as UserRole) || 'playerA';
+  const isMobile = window.innerWidth < 768;
+
+  // Initialize game if needed
+  useState(() => {
+    if (gameId && gameId !== state.gameId) {
+      actions.startGame(gameId);
+    }
+  });
+
+  const currentGameId = gameId || state.gameId;
+  const questions = getQuestionsForSegment(state.currentSegment);
+
+  const handleNextQuestion = () => {
+    actions.nextQuestion();
+  };
+
+  const handleNextSegment = () => {
+    actions.nextSegment();
+  };
+
+  const handleAddStrike = (playerId: 'playerA' | 'playerB') => {
+    actions.addStrike(playerId);
+  };
+
+  const handleUpdateScore = (
+    playerId: 'playerA' | 'playerB',
+    points: number,
+  ) => {
+    actions.updateScore(playerId, points);
+  };
+
+  if (!currentGameId) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 flex items-center justify-center">
+        <div className="text-white text-center font-arabic">
+          <h1 className="text-2xl mb-4">جاري التحميل...</h1>
+        </div>
+      </div>
+    );
+  }
+
+  // Host PC View
+  if (userRole === 'host' && !isMobile) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 p-6">
+        <div className="max-w-7xl mx-auto">
+          {/* Header */}
+          <div className="text-center mb-6">
+            <h1 className="text-3xl font-bold text-white mb-2 font-arabic">
+              {state.currentSegment} - السؤال{' '}
+              {state.segments[state.currentSegment].currentQuestionIndex + 1}
+            </h1>
+            <p className="text-accent2 font-arabic">
+              رمز الجلسة: {currentGameId}
+            </p>
+          </div>
+
+          {/* Host Controls */}
+          <div className="grid md:grid-cols-4 gap-4 mb-6">
+            <button
+              onClick={handleNextQuestion}
+              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-xl font-arabic"
+            >
+              السؤال التالي
+            </button>
+            <button
+              onClick={handleNextSegment}
+              className="bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-xl font-arabic"
+            >
+              الفقرة التالية
+            </button>
+            <button
+              onClick={() => handleAddStrike('playerA')}
+              className="bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-6 rounded-xl font-arabic"
+            >
+              خطأ لاعب أ
+            </button>
+            <button
+              onClick={() => handleAddStrike('playerB')}
+              className="bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-6 rounded-xl font-arabic"
+            >
+              خطأ لاعب ب
+            </button>
+          </div>
+
+          <div className="grid lg:grid-cols-2 gap-6">
+            {/* Question Area */}
+            <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6">
+              <h2 className="text-xl font-bold text-white mb-4 font-arabic">
+                منطقة الأسئلة
+              </h2>
+              {questions.length > 0 && (
+                <div className="space-y-4">
+                  <div className="bg-white/20 rounded-lg p-4">
+                    <p className="text-white font-arabic mb-2">السؤال:</p>
+                    <p className="text-accent2 font-arabic text-lg">
+                      {questions[0]?.text}
+                    </p>
+                  </div>
+                  <div className="bg-white/20 rounded-lg p-4">
+                    <p className="text-white font-arabic mb-2">الإجابات:</p>
+                    <ul className="space-y-1">
+                      {questions[0]?.answers.map((answer, index) => (
+                        <li key={index} className="text-accent2 font-arabic">
+                          • {answer}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+
+              {/* Score Update Controls */}
+              <div className="mt-6 space-y-3">
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleUpdateScore('playerA', 1)}
+                    className="flex-1 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg font-arabic"
+                  >
+                    +1 لاعب أ
+                  </button>
+                  <button
+                    onClick={() => handleUpdateScore('playerB', 1)}
+                    className="flex-1 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg font-arabic"
+                  >
+                    +1 لاعب ب
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Scoreboard */}
+            <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6">
+              <Scoreboard />
+            </div>
+          </div>
+
+          {/* Video Chat Areas */}
+          <div className="grid md:grid-cols-2 gap-6 mt-6">
+            <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-4">
+              <h3 className="font-bold text-white mb-2 font-arabic">لاعب أ</h3>
+              <div className="aspect-video bg-black/30 rounded-lg"></div>
+            </div>
+            <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-4">
+              <h3 className="font-bold text-white mb-2 font-arabic">لاعب ب</h3>
+              <div className="aspect-video bg-black/30 rounded-lg"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Mobile Player View
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 flex flex-col">
+      {/* Header */}
+      <div className="text-center p-4 bg-black/20">
+        <h1 className="text-xl font-bold text-white mb-1 font-arabic">
+          {state.currentSegment}
+        </h1>
+        <p className="text-accent2 text-sm font-arabic">
+          السؤال {state.segments[state.currentSegment].currentQuestionIndex + 1}{' '}
+          من {state.segments[state.currentSegment].questionsPerSegment}
+        </p>
+      </div>
+
+      {/* Timer */}
+      <div className="p-4">
+        <Timer />
+      </div>
+
+      {/* Scoreboard */}
+      <div className="px-4 pb-4">
+        <Scoreboard />
+      </div>
+
+      {/* Question Area */}
+      <div className="flex-1 p-4">
+        <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-4 h-full">
+          {/* Hide question text for BELL and SING segments */}
+          {state.currentSegment !== 'BELL' &&
+            state.currentSegment !== 'SING' &&
+            questions.length > 0 && (
+              <div className="mb-4">
+                <p className="text-white font-arabic text-center text-lg">
+                  {questions[0]?.text}
+                </p>
+              </div>
+            )}
+
+          {/* Bell segment buzzer */}
+          {state.currentSegment === 'BELL' && (
+            <div className="flex items-center justify-center h-full">
+              <Buzzer />
+            </div>
+          )}
+
+          {/* Other segments - waiting area */}
+          {state.currentSegment !== 'BELL' && (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-white/70 font-arabic text-center">
+                انتظر المقدم...
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Scoreboard.tsx
+++ b/src/pages/Scoreboard.tsx
@@ -1,0 +1,3 @@
+export default function Scoreboard() {
+  return <div className="p">Scoreboard Page</div>;
+}

--- a/src/pages/SegmentIntro.tsx
+++ b/src/pages/SegmentIntro.tsx
@@ -1,0 +1,3 @@
+export default function SegmentIntro() {
+  return <div className="p">Segment Intro Page</div>;
+}

--- a/src/themes/clubs.ts
+++ b/src/themes/clubs.ts
@@ -1,0 +1,14 @@
+export const CLUB_THEMES = {
+  liverpool: {
+    primary: 'bg-[#c8102e]', // Liverpool red
+    accent: 'bg-[#00b2a9]', // Liverpool teal
+    text: 'text-white',
+    logo: '/assets/liverpool.png',
+  },
+  madrid: {
+    primary: 'bg-[#ffffff]', // Madrid white
+    accent: 'bg-[#febd2f]', // Madrid gold
+    text: 'text-black',
+    logo: '/assets/realmadrid.png',
+  },
+};


### PR DESCRIPTION
## Summary
- restore legacy pages under `src/pages`
- merge lobby logic from TrueLobby
- update routes and imports to use alias paths
- add club theme file

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688954b4fdd0833099feb530e1e31f6d