### PR TITLE
Fix build errors with TS path resolution

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 dist
+public

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -191,10 +191,7 @@ export default function TrueLobby() {
                 <p className="text-white font-arabic mb-2">إعدادات الأسئلة:</p>
                 <div className="text-sm text-white/70 font-arabic space-y-1">
                   {Object.entries(state.segments).map(
-                    ([segmentCode, segment]: [
-                      import('@/types/game').SegmentCode,
-                      import('@/types/game').SegmentState,
-                    ]) => (
+                    ([segmentCode, segment]) => (
                       <div key={segmentCode} className="flex justify-between">
                         <span>{segmentCode}:</span>
                         <span>{segment.questionsPerSegment} سؤال</span>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",


### PR DESCRIPTION
## Summary
- extend app/node tsconfigs from root to ensure `@` alias works
- ignore built JS in `public` for prettier
- fix segment settings loop type in `Lobby`

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889686791b883308ea418de31a11c31