### PR TITLE
Fix Vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/',
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- set `base: '/'` in `vite.config.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889ba6f286c8330ac57210879f4ba70