### PR TITLE
Update game types to match database

### DIFF
--- a/full-dependency-map.json
+++ b/full-dependency-map.json
@@ -6,18 +6,12 @@
   "src/App.tsx": [],
   "src/components/Buzzer.tsx": [],
   "src/components/ConnectionBanner.tsx": [],
-  "src/components/Scoreboard.tsx": [
-    "src/types/game.ts"
-  ],
+  "src/components/Scoreboard.tsx": [],
   "src/components/Timer.tsx": [],
   "src/components/VideoRoom.tsx": [],
   "src/context/GameContext.tsx": [],
-  "src/context/GameContextDefinition.ts": [
-    "src/types/game.ts"
-  ],
-  "src/data/questions.ts": [
-    "src/types/game.ts"
-  ],
+  "src/context/GameContextDefinition.ts": [],
+  "src/data/questions.ts": [],
   "src/hooks/useErrorLog.ts": [],
   "src/hooks/useGame.ts": [],
   "src/hooks/useSupabaseFetch.ts": [],

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 import { useGame } from '@/hooks/useGame';
-import type { PlayerId } from '../types/game';
+import type { PlayerId } from '@/types/game';
 
 export default function Scoreboard() {
   const { state } = useGame();
@@ -83,7 +83,7 @@ export default function Scoreboard() {
             <div
               key={index}
               className={`w-3 h-3 rounded-full ${
-                index < player.strikes ? 'bg-red-500' : 'bg-white/20'
+                index < (player.strikes ?? 0) ? 'bg-red-500' : 'bg-white/20'
               }`}
             />
           ))}
@@ -148,10 +148,12 @@ export default function Scoreboard() {
         <div className="text-accent2 font-arabic text-lg">
           {state.currentSegment}
         </div>
-        <div className="text-white/70 text-sm font-arabic">
-          السؤال {state.segments[state.currentSegment].currentQuestionIndex + 1}{' '}
-          من {state.segments[state.currentSegment].questionsPerSegment}
-        </div>
+        {state.currentSegment && (
+          <div className="text-white/70 text-sm font-arabic">
+            السؤال {state.currentQuestionIndex + 1} من{' '}
+            {state.segmentSettings[state.currentSegment]}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -31,11 +31,11 @@ export default function VideoRoom({
 
     try {
       // Get Daily.co token for this user
-      const tokenResult = await actions.generateDailyToken(
+      const tokenResult = (await actions.generateDailyToken(
         gameId,
         userName,
         userRole === 'host-mobile',
-      );
+      )) as any;
       if (!tokenResult.success) {
         throw new Error(tokenResult.error || 'Failed to get access token');
       }
@@ -87,7 +87,7 @@ export default function VideoRoom({
       // Join the meeting
       await (callObject as any).join({
         url: state.videoRoomUrl,
-        token: tokenResult.token,
+        token: (tokenResult as any).token,
         userName: userName,
         startVideoOff: false,
         startAudioOff: false,

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+import type { GameState } from '@/types/game';
 
 /**
  * Basic game context used during early development. Consumers can access
@@ -6,17 +7,56 @@ import React, { createContext, useContext, useReducer, ReactNode } from 'react';
  * `GameState` interface with any additional properties needed as features
  * are implemented.
  */
-export interface GameState {
-  // Extend this interface with any state needed for your tests
-  playerName?: string;
-}
-
 interface GameContextValue {
   state: GameState;
   dispatch: React.Dispatch<Partial<GameState>>;
+  // Placeholder until real actions are implemented
+  actions: Record<string, (...args: unknown[]) => unknown>;
 }
 
-const initialState: GameState = {};
+const initialState: GameState = {
+  gameId: '',
+  hostCode: '',
+  hostName: '',
+  phase: 'CONFIG',
+  currentSegment: null,
+  currentQuestionIndex: 0,
+  videoRoomCreated: false,
+  timer: 0,
+  isTimerRunning: false,
+  segmentSettings: {
+    WSHA: 0,
+    AUCT: 0,
+    BELL: 0,
+    SING: 0,
+    REMO: 0,
+  },
+  players: {
+    playerA: {
+      id: 'playerA',
+      name: '',
+      score: 0,
+      isConnected: false,
+      specialButtons: {
+        LOCK_BUTTON: false,
+        TRAVELER_BUTTON: false,
+        PIT_BUTTON: false,
+      },
+    },
+    playerB: {
+      id: 'playerB',
+      name: '',
+      score: 0,
+      isConnected: false,
+      specialButtons: {
+        LOCK_BUTTON: false,
+        TRAVELER_BUTTON: false,
+        PIT_BUTTON: false,
+      },
+    },
+  },
+  scoreHistory: [],
+};
 
 // Export the context so hooks importing from this module share the same
 // instance provided by `GameProvider`. Creating a second context would
@@ -32,7 +72,7 @@ function reducer(state: GameState, update: Partial<GameState>): GameState {
 export function GameProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
-    <GameContext.Provider value={{ state, dispatch }}>
+    <GameContext.Provider value={{ state, dispatch, actions: {} }}>
       {children}
     </GameContext.Provider>
   );

--- a/src/context/GameContextDefinition.ts
+++ b/src/context/GameContextDefinition.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { GameState, PlayerId, SegmentCode } from '../types/game';
+import type { GameState, PlayerId, SegmentCode } from '@/types/game';
 
 interface GameContextType {
   state: GameState;

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,4 +1,4 @@
-import type { Question, SegmentCode } from '../types/game';
+import type { Question, SegmentCode } from '@/types/game';
 
 // Comprehensive questions database for each segment
 export const sampleQuestions: Record<SegmentCode, Question[]> = {

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -33,7 +33,9 @@ export default function TrueLobby() {
       gameId
     ) {
       setIsCreatingRoom(true);
-      actions.createVideoRoom(gameId).finally(() => setIsCreatingRoom(false));
+      (actions.createVideoRoom(gameId) as Promise<unknown>).finally(() =>
+        setIsCreatingRoom(false),
+      );
     }
   }, [myParticipant, state.videoRoomCreated, gameId, actions]);
 
@@ -118,7 +120,11 @@ export default function TrueLobby() {
 
     setIsCreatingRoom(true);
     try {
-      const result = await actions.createVideoRoom(gameId);
+      const result = (await actions.createVideoRoom(gameId)) as {
+        success: boolean;
+        roomUrl?: string;
+        error?: string;
+      };
       if (!result.success) {
         console.error('Failed to create room:', result.error);
         alert('فشل في إنشاء غرفة الفيديو: ' + result.error);
@@ -190,11 +196,11 @@ export default function TrueLobby() {
               <div>
                 <p className="text-white font-arabic mb-2">إعدادات الأسئلة:</p>
                 <div className="text-sm text-white/70 font-arabic space-y-1">
-                  {Object.entries(state.segments).map(
-                    ([segmentCode, segment]) => (
+                  {Object.entries(state.segmentSettings).map(
+                    ([segmentCode, count]) => (
                       <div key={segmentCode} className="flex justify-between">
                         <span>{segmentCode}:</span>
-                        <span>{segment.questionsPerSegment} سؤال</span>
+                        <span>{count} سؤال</span>
                       </div>
                     ),
                   )}
@@ -380,7 +386,7 @@ export default function TrueLobby() {
                     </div>
 
                     <div className="text-white/60 text-sm font-arabic">
-                      النقاط: {player.score} | الأخطاء: {player.strikes}/3
+                      النقاط: {player.score} | الأخطاء: {player.strikes ?? 0}/3
                     </div>
                   </div>
                 ) : (

--- a/src/pages/QuizRoom.tsx
+++ b/src/pages/QuizRoom.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useGame } from '@/hooks/useGame';
 import { getQuestionsForSegment } from '@/data/questions';
+import type { SegmentCode } from '@/types/game';
 import Buzzer from '@/components/Buzzer';
 import Scoreboard from '@/components/Scoreboard';
 import Timer from '@/components/Timer';
@@ -24,7 +25,7 @@ export default function QuizRoom() {
   });
 
   const currentGameId = gameId || state.gameId;
-  const questions = getQuestionsForSegment(state.currentSegment);
+  const questions = getQuestionsForSegment(state.currentSegment as SegmentCode);
 
   const handleNextQuestion = () => {
     actions.nextQuestion();
@@ -63,8 +64,7 @@ export default function QuizRoom() {
           {/* Header */}
           <div className="text-center mb-6">
             <h1 className="text-3xl font-bold text-white mb-2 font-arabic">
-              {state.currentSegment} - السؤال{' '}
-              {state.segments[state.currentSegment].currentQuestionIndex + 1}
+              {state.currentSegment} - السؤال {state.currentQuestionIndex + 1}
             </h1>
             <p className="text-accent2 font-arabic">
               رمز الجلسة: {currentGameId}
@@ -178,8 +178,10 @@ export default function QuizRoom() {
           {state.currentSegment}
         </h1>
         <p className="text-accent2 text-sm font-arabic">
-          السؤال {state.segments[state.currentSegment].currentQuestionIndex + 1}{' '}
-          من {state.segments[state.currentSegment].questionsPerSegment}
+          السؤال {state.currentQuestionIndex + 1} من{' '}
+          {state.currentSegment
+            ? state.segmentSettings[state.currentSegment]
+            : 0}
         </p>
       </div>
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,7 +1,11 @@
 // Game Types for Thirty Challenge Quiz
 export type PlayerId = 'playerA' | 'playerB';
 export type SegmentCode = 'WSHA' | 'AUCT' | 'BELL' | 'SING' | 'REMO';
-export type GamePhase = 'LOBBY' | 'PLAYING' | 'FINAL_SCORES';
+export type GamePhase =
+  | 'CONFIG' // PC host is choosing settings
+  | 'LOBBY' // waiting room, video up
+  | 'PLAYING' // questions in progress
+  | 'COMPLETED'; // final scores shown
 
 export interface Player {
   id: PlayerId;
@@ -9,7 +13,7 @@ export interface Player {
   flag?: string;
   club?: string;
   score: number;
-  strikes: number;
+  strikes?: number; // resets each question
   isConnected: boolean;
   specialButtons: {
     LOCK_BUTTON: boolean; // AUCT segment - available at 40 points
@@ -42,17 +46,31 @@ export interface ScoreEvent {
 }
 
 export interface GameState {
+  // identity
   gameId: string;
+  hostCode: string;
+  hostName: string;
+
+  // progress
   phase: GamePhase;
-  currentSegment: SegmentCode;
+  currentSegment: SegmentCode | null; // null until PLAYING
   currentQuestionIndex: number;
+
+  // video
+  videoRoomUrl?: string;
+  videoRoomCreated: boolean;
+
+  // timing
   timer: number;
   isTimerRunning: boolean;
-  videoRoomUrl?: string;
-  videoRoomCreated?: boolean;
+
+  // configuration
+  segmentSettings: Record<SegmentCode, number>;
+
+  // live participants
   players: Record<PlayerId, Player>;
-  hostName: string;
-  segments: Record<SegmentCode, SegmentState>;
+
+  // history / analytics
   scoreHistory: ScoreEvent[];
 }
 
@@ -61,6 +79,7 @@ export interface StartGameAction {
   type: 'START_GAME';
   payload: {
     gameId: string;
+    hostCode: string;
   };
 }
 


### PR DESCRIPTION
## Summary
- refine GamePhase enumeration
- overhaul GameState to include hostCode and segmentSettings
- document optional strikes field
- adjust related imports across the app
- update context initial state and scoreboard/quiz room logic
- add type assertions where needed to satisfy tsc

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `pnpm exec tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688a5680fb10833083a6a466540faab6