### PR TITLE
feat(context): real Game reducer + session flow

### DIFF
--- a/src/context/gameReducer.ts
+++ b/src/context/gameReducer.ts
@@ -1,0 +1,80 @@
+import produce from 'immer';
+import type {
+  GameState,
+  GamePhase,
+  SegmentCode,
+  Player,
+  PlayerId,
+  ScoreEvent,
+} from '@/types/game';
+
+export type GameAction =
+  | { type: 'INIT'; payload: GameState }
+  | { type: 'SET_PHASE'; phase: GamePhase }
+  | { type: 'SET_CURRENT_SEGMENT'; segment: SegmentCode | null }
+  | { type: 'ADVANCE_QUESTION' }
+  | { type: 'ADD_PLAYER'; player: Player }
+  | { type: 'UPDATE_PLAYER'; id: PlayerId; partial: Partial<Player> }
+  | { type: 'UPDATE_TIMER'; timer: number; isRunning: boolean }
+  | { type: 'PUSH_SCORE_EVENT'; event: ScoreEvent }
+  | { type: 'RESET_STRIKES' }
+  | { type: 'COMPLETE_GAME' };
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  return produce(state, draft => {
+    switch (action.type) {
+      case 'INIT':
+        return action.payload;
+
+      case 'SET_PHASE':
+        draft.phase = action.phase;
+        if (action.phase === 'CONFIG') draft.currentSegment = null;
+        return;
+
+      case 'SET_CURRENT_SEGMENT':
+        draft.currentSegment = action.segment;
+        draft.currentQuestionIndex = 0;
+        draft.timer = 0;
+        draft.isTimerRunning = false;
+        return;
+
+      case 'ADVANCE_QUESTION':
+        draft.currentQuestionIndex += 1;
+        draft.timer = 0;
+        draft.isTimerRunning = false;
+        draft.players = Object.fromEntries(
+          Object.entries(draft.players).map(([id, p]) => [
+            id,
+            { ...p, strikes: 0 },
+          ]),
+        );
+        return;
+
+      case 'ADD_PLAYER':
+        draft.players[action.player.id] = action.player;
+        return;
+
+      case 'UPDATE_PLAYER':
+        Object.assign(draft.players[action.id], action.partial);
+        return;
+
+      case 'UPDATE_TIMER':
+        draft.timer = action.timer;
+        draft.isTimerRunning = action.isRunning;
+        return;
+
+      case 'PUSH_SCORE_EVENT':
+        draft.scoreHistory.push(action.event);
+        return;
+
+      case 'RESET_STRIKES':
+        Object.values(draft.players).forEach(p => (p.strikes = 0));
+        return;
+
+      case 'COMPLETE_GAME':
+        draft.phase = 'COMPLETED';
+        draft.isTimerRunning = false;
+        return;
+    }
+  });
+}

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -1,12 +1,1 @@
-import { useContext } from 'react';
-// Import the context definition from the same file that exports
-// `GameProvider` to ensure both share the exact context instance.
-import { GameContext } from '@/context/GameContext';
-
-export function useGame() {
-  const context = useContext(GameContext);
-  if (context === undefined) {
-    throw new Error('useGame must be used within a GameProvider');
-  }
-  return context;
-}
+export { useGame } from '@/context/GameContext';

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --brand-dark: #19194d;
+  --brand-grad: #6e45e2;
+  --brand-light: #efefef;
+  --accent-blue: #50aaf2;
+  --font-header: 'DG Bebo', sans-serif;
+  --font-body: 'Almarai', sans-serif;
+}
+
 @font-face {
   font-family: 'DG Bebo';
   src: url('/tahadialthalatheen/fonts/DG-BeboT.ttf') format('truetype');

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 export default function Landing() {
   const navigate = useNavigate();
-  const { actions } = useGame();
+  const { startSession } = useGame();
   const [isCreating, setIsCreating] = useState(false);
   const [customGameId, setCustomGameId] = useState('');
   const [useCustomId, setUseCustomId] = useState(false);
@@ -19,8 +19,14 @@ export default function Landing() {
           ? customGameId.trim().toUpperCase()
           : Math.random().toString(36).substring(2, 8).toUpperCase();
 
-      // Initialize the game
-      actions.startGame(gameId);
+      // Persist new session then move to host setup
+      await startSession(gameId, `${gameId}-HOST`, {
+        WSHA: 4,
+        AUCT: 4,
+        BELL: 10,
+        SING: 10,
+        REMO: 4,
+      });
 
       // Navigate to host setup page
       navigate(`/host-setup/${gameId}`, { replace: true });
@@ -41,6 +47,12 @@ export default function Landing() {
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.96 }}
     >
+      <img
+        src="/tahadialthalatheen/images/Logo.png"
+        alt="تحدي الثلاثين"
+        className="w-32 mb-6"
+      />
+
       <motion.h1
         className="text-5xl sm:text-7xl font-extrabold mb-6 text-accent glow font-arabic text-center"
         style={{

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -18,7 +18,7 @@ export default function TrueLobby() {
   const { gameId } = useParams<{ gameId: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { state, actions } = useGame();
+  const { state, startGame, actions } = useGame();
 
   const [myParticipant, setMyParticipant] = useState<LobbyParticipant | null>(
     null,
@@ -48,7 +48,7 @@ export default function TrueLobby() {
 
     // Initialize game if needed
     if (state.gameId !== gameId) {
-      actions.startGame(gameId);
+      startGame();
     }
 
     // Determine my role from URL parameters
@@ -112,7 +112,7 @@ export default function TrueLobby() {
     if (participant) {
       actions.trackPresence(participant);
     }
-  }, [gameId, searchParams, state.gameId, state.hostName, actions]);
+  }, [gameId, searchParams, state.gameId, state.hostName, actions, startGame]);
 
   // Create video room when host PC clicks button
   const handleCreateVideoRoom = async () => {

--- a/src/pages/QuizRoom.tsx
+++ b/src/pages/QuizRoom.tsx
@@ -12,7 +12,7 @@ type UserRole = 'host' | 'playerA' | 'playerB';
 export default function QuizRoom() {
   const { gameId } = useParams<{ gameId: string }>();
   const [searchParams] = useSearchParams();
-  const { state, actions } = useGame();
+  const { state, startGame, advanceQuestion, actions } = useGame();
 
   const userRole = (searchParams.get('role') as UserRole) || 'playerA';
   const isMobile = window.innerWidth < 768;
@@ -20,7 +20,7 @@ export default function QuizRoom() {
   // Initialize game if needed
   useState(() => {
     if (gameId && gameId !== state.gameId) {
-      actions.startGame(gameId);
+      startGame();
     }
   });
 
@@ -28,7 +28,7 @@ export default function QuizRoom() {
   const questions = getQuestionsForSegment(state.currentSegment as SegmentCode);
 
   const handleNextQuestion = () => {
-    actions.nextQuestion();
+    advanceQuestion();
   };
 
   const handleNextSegment = () => {


### PR DESCRIPTION
## Summary
- implement typed `gameReducer` and actions
- add `startSession`, `startGame`, `advanceQuestion` helpers
- wire landing page to create sessions in Supabase
- show branded logo and CSS variables

## Testing
- `pnpm run lint`
- `npx tsc --noEmit`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688a60b070ec8330b145b1e71094da12