### PR TITLE
Fix runtime import cycle

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -5,39 +5,12 @@ import {
   ReactNode,
   useEffect,
 } from 'react';
-import type { GameState, SegmentCode, Player, PlayerId } from '@/types/game';
+import type { GameState, SegmentCode } from '@/types/game';
 import { GameDatabase, type GameRecord } from '@/lib/gameDatabase';
 import { attachGameSync } from '@/lib/gameSync';
 import { gameReducer, type GameAction } from './gameReducer';
 import { initialGameState } from './initialGameState';
-
-/** Default player objects used when initializing game state */
-export const defaultPlayers: Record<PlayerId, Player> = {
-  playerA: {
-    id: 'playerA',
-    name: '',
-    score: 0,
-    strikes: 0,
-    isConnected: false,
-    specialButtons: {
-      LOCK_BUTTON: false,
-      TRAVELER_BUTTON: false,
-      PIT_BUTTON: false,
-    },
-  },
-  playerB: {
-    id: 'playerB',
-    name: '',
-    score: 0,
-    strikes: 0,
-    isConnected: false,
-    specialButtons: {
-      LOCK_BUTTON: false,
-      TRAVELER_BUTTON: false,
-      PIT_BUTTON: false,
-    },
-  },
-};
+import { defaultPlayers } from './defaults';
 
 /** Map a Supabase record to our internal GameState shape */
 export function mapRecordToState(record: GameRecord): GameState {
@@ -54,6 +27,7 @@ export function mapRecordToState(record: GameRecord): GameState {
     timer: record.timer,
     isTimerRunning: record.is_timer_running,
     segmentSettings: record.segment_settings as Record<SegmentCode, number>,
+    players: defaultPlayers,
   };
 }
 

--- a/src/context/defaults.ts
+++ b/src/context/defaults.ts
@@ -1,0 +1,34 @@
+import type { Player } from '@/types/game';
+
+export const defaultPlayers: Record<string, Player> = {
+  playerA: {
+    id: 'playerA',
+    name: '',
+    flag: '',
+    club: '',
+    role: 'playerA',
+    score: 0,
+    strikes: 0,
+    isConnected: false,
+    specialButtons: {
+      LOCK_BUTTON: false,
+      TRAVELER_BUTTON: false,
+      PIT_BUTTON: false,
+    },
+  },
+  playerB: {
+    id: 'playerB',
+    name: '',
+    flag: '',
+    club: '',
+    role: 'playerB',
+    score: 0,
+    strikes: 0,
+    isConnected: false,
+    specialButtons: {
+      LOCK_BUTTON: false,
+      TRAVELER_BUTTON: false,
+      PIT_BUTTON: false,
+    },
+  },
+};

--- a/src/context/initialGameState.ts
+++ b/src/context/initialGameState.ts
@@ -1,5 +1,5 @@
 import type { GameState } from '@/types/game';
-import { defaultPlayers } from './GameContext';
+import { defaultPlayers } from './defaults';
 
 export const initialGameState: GameState = {
   gameId: '',

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -12,6 +12,8 @@ export interface Player {
   name: string;
   flag?: string;
   club?: string;
+  /** Role of the player e.g. 'playerA' or 'playerB' */
+  role?: string;
   score: number;
   strikes?: number; // resets each question
   isConnected: boolean;


### PR DESCRIPTION
## Summary
- break circular import crash by moving `defaultPlayers` into `defaults.ts`
- import that data in `GameContext` and `initialGameState`
- extend `Player` type with optional `role`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a79c106908330a7025046fd99d428