### PR TITLE
feat(video): Daily token + Join routes

### DIFF
--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -16,7 +16,7 @@ export default function VideoRoom({
   userRole,
   className = '',
 }: VideoRoomProps) {
-  const { state, actions } = useGame();
+  const { state, generateDailyToken } = useGame();
   const callFrameRef = useRef<HTMLDivElement>(null);
   const callObjectRef = useRef<unknown>(null);
   const [isJoining, setIsJoining] = useState(false);
@@ -31,13 +31,13 @@ export default function VideoRoom({
 
     try {
       // Get Daily.co token for this user
-      const tokenResult = (await actions.generateDailyToken(
+      const token = await generateDailyToken(
         gameId,
         userName,
         userRole === 'host-mobile',
-      )) as any;
-      if (!tokenResult.success) {
-        throw new Error(tokenResult.error || 'Failed to get access token');
+      );
+      if (!token) {
+        throw new Error('Failed to get access token');
       }
 
       // Create Daily call object
@@ -87,8 +87,8 @@ export default function VideoRoom({
       // Join the meeting
       await (callObject as any).join({
         url: state.videoRoomUrl,
-        token: (tokenResult as any).token,
-        userName: userName,
+        token,
+        userName,
         startVideoOff: false,
         startAudioOff: false,
       });
@@ -102,7 +102,7 @@ export default function VideoRoom({
       setError(errorMessage);
       setIsJoining(false);
     }
-  }, [actions, gameId, userName, userRole, state.videoRoomUrl]);
+  }, [generateDailyToken, gameId, userName, userRole, state.videoRoomUrl]);
 
   // Join the video call when room is available
   useEffect(() => {

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -111,18 +111,32 @@ export function useGame() {
     return { success: true };
   };
 
+  /**
+   * Request a Daily.co meeting token for a participant.
+   *
+   * @param room - Daily.co room name
+   * @param user - Display name for the token
+   * @param isHost - Whether the user should have host privileges
+   * @returns The token string, or null if generation failed
+   */
   const generateDailyToken = async (
     room: string,
     user: string,
     isHost: boolean,
-  ) => {
-    const result = (await callFn('create-daily-token', {
-      room,
-      user,
-      isHost,
-    })) as { token?: string; error?: string };
-    if (result.token) return { success: true, token: result.token };
-    return { success: false, error: result.error || 'token failed' };
+  ): Promise<string | null> => {
+    try {
+      const res = await fetch('/.netlify/functions/create-daily-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ room, user, isHost }),
+      });
+      const json = (await res.json()) as { token?: string; error?: string };
+      if (!json.token) throw new Error(json.error || 'No token');
+      return json.token;
+    } catch (err) {
+      console.error('generateDailyToken error', err);
+      return null;
+    }
   };
 
   // Return legacy actions object for backward compatibility

--- a/src/pages/ControlRoom.tsx
+++ b/src/pages/ControlRoom.tsx
@@ -7,8 +7,7 @@ import VideoRoom from '@/components/VideoRoom';
  * quick controls for starting the game or advancing questions.
  */
 export default function ControlRoom() {
-  const { state, startGame, advanceQuestion, createVideoRoom, endVideoRoom } =
-    useGame();
+  const { state, startGame, createVideoRoom, endVideoRoom } = useGame();
 
   const handleCreate = async () => {
     if (!state.gameId) return;
@@ -45,13 +44,6 @@ export default function ControlRoom() {
         >
           ابدأ اللعبة
         </button>
-        <button
-          onClick={() => advanceQuestion()}
-          disabled={state.phase !== 'PLAYING'}
-          className="px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white rounded-lg font-arabic"
-        >
-          السؤال التالي
-        </button>
         {!state.videoRoomCreated ? (
           <button
             onClick={handleCreate}
@@ -71,35 +63,36 @@ export default function ControlRoom() {
 
       {/* Video tiles grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Host mobile video */}
-        <div>
-          <h3 className="text-center text-white font-arabic mb-2">المقدم</h3>
-          <VideoRoom
-            gameId={state.gameId}
-            userName={state.hostName ?? 'المقدم'}
-            userRole="host-mobile"
-          />
-        </div>
-
-        {/* Player A video */}
-        <div>
-          <h3 className="text-center text-white font-arabic mb-2">لاعب 1</h3>
-          <VideoRoom
-            gameId={state.gameId}
-            userName={state.players.playerA.name || 'Player A'}
-            userRole="playerA"
-          />
-        </div>
-
-        {/* Player B video */}
-        <div>
-          <h3 className="text-center text-white font-arabic mb-2">لاعب 2</h3>
-          <VideoRoom
-            gameId={state.gameId}
-            userName={state.players.playerB.name || 'Player B'}
-            userRole="playerB"
-          />
-        </div>
+        {(
+          [
+            {
+              id: 'host-mobile',
+              label: 'المقدم',
+              name: state.hostName ?? 'المقدم',
+            },
+            {
+              id: 'playerA',
+              label: 'لاعب 1',
+              name: state.players.playerA.name || 'Player A',
+            },
+            {
+              id: 'playerB',
+              label: 'لاعب 2',
+              name: state.players.playerB.name || 'Player B',
+            },
+          ] as const
+        ).map((p) => (
+          <div key={p.id as string}>
+            <h3 className="text-center text-white font-arabic mb-2">
+              {p.label}
+            </h3>
+            <VideoRoom
+              gameId={state.gameId}
+              userName={p.name}
+              userRole={p.id as 'host-mobile' | 'playerA' | 'playerB'}
+            />
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `generateDailyToken` helper inside `GameContext`
- wire `VideoRoom` to use that token
- fix host and player joining logic
- remove question navigation from ControlRoom and map video tiles

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a8d68fb74833083e9a7d1db7e40e5