### PR TITLE
Implement game actions and reducer

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -93,7 +93,6 @@ Can be modified by agent/gpt.
 ## ✅ Approved Changes
 
 - **Dual Host Control**
-
   - Host can join via _mobile_ to see what players see.
   - Host can also join via _PC_ with advanced controls:
     - View all questions/answers
@@ -104,9 +103,9 @@ Can be modified by agent/gpt.
     - Move to next question or segment
     - Lock inputs after bell click
     - Flexible host control over game state
+    - GameContext actions persist to Supabase and broadcast via GameSync
 
 - **Segment-Specific Behavior**
-
   - **BELLJ** and **SING**:
     - Question hidden from players.
     - Players race to click a shared "bell" button.
@@ -116,11 +115,9 @@ Can be modified by agent/gpt.
     - Host picks correct/incorrect via ui.
 
 - **REMO** Logic:
-
   - Host clicks to reveal club logos step-by.s
 
 - **Pre-Game Lobby Settings**
-
   - Host PC lobby view:
     - Set number of questions per segment
     - [Suggestions]: choose enabled segments, customize team logos, toggle special buttons)

--- a/full-dependency-map.json
+++ b/full-dependency-map.json
@@ -16,7 +16,9 @@
   ],
   "src/context/GameContextDefinition.ts": [],
   "src/context/defaults.ts": [],
-  "src/context/gameReducer.ts": [],
+  "src/context/gameReducer.ts": [
+    "src/context/initialGameState.ts"
+  ],
   "src/context/initialGameState.ts": [
     "src/context/defaults.ts"
   ],

--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -85,6 +85,7 @@ export default function VideoRoom({
         });
 
       // Join the meeting
+      if (!state.videoRoomUrl) throw new Error('Missing room URL');
       await (callObject as any).join({
         url: state.videoRoomUrl,
         token,
@@ -165,7 +166,7 @@ export default function VideoRoom({
     );
   }
 
-  if (!state.videoRoomCreated) {
+  if (!state.videoRoomCreated || !state.videoRoomUrl) {
     return (
       <div
         className={`bg-gray-500/20 border border-gray-500/30 rounded-xl p-6 ${className}`}

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -4,10 +4,11 @@ import {
   useReducer,
   ReactNode,
   useEffect,
+  useRef,
 } from 'react';
-import type { GameState, SegmentCode } from '@/types/game';
+import type { GameState, SegmentCode, PlayerId } from '@/types/game';
 import { GameDatabase, type GameRecord } from '@/lib/gameDatabase';
-import { attachGameSync } from '@/lib/gameSync';
+import { attachGameSync, createGameSync, type GameSync } from '@/lib/gameSync';
 import { gameReducer, type GameAction } from './gameReducer';
 import { initialGameState } from './initialGameState';
 import { defaultPlayers } from './defaults';
@@ -37,10 +38,27 @@ export const GameContext = createContext<
 
 export function GameProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(gameReducer, initialGameState);
+  const gameSyncRef = useRef<GameSync | null>(null);
   useEffect(() => {
     if (!state.gameId) return;
     const detach = attachGameSync(state.gameId, dispatch);
-    return () => detach();
+    if (!gameSyncRef.current) {
+      const gs = createGameSync(state.gameId, {
+        onGameStateUpdate: (gs) =>
+          dispatch({ type: 'INIT', payload: { ...state, ...gs } as GameState }),
+        onPlayerJoin: () => {},
+        onPlayerLeave: () => {},
+        onHostUpdate: () => {},
+        onVideoRoomUpdate: () => {},
+      });
+      void gs.connect();
+      gameSyncRef.current = gs;
+    }
+    return () => {
+      detach();
+      gameSyncRef.current?.disconnect();
+      gameSyncRef.current = null;
+    };
   }, [state.gameId]);
   return (
     <GameContext.Provider value={{ state, dispatch }}>
@@ -139,8 +157,155 @@ export function useGame() {
     }
   };
 
-  // Return legacy actions object for backward compatibility
-  const actions: Record<string, (...args: unknown[]) => unknown> = {};
+  const actions = {
+    startGame: async (gameId: string, hostName?: string) => {
+      dispatch({
+        type: 'START_GAME',
+        payload: { gameId, hostCode: state.hostCode },
+      });
+      await GameDatabase.updateGame(gameId, {
+        phase: 'PLAYING',
+        host_name: hostName ?? state.hostName,
+      });
+      await gameSyncRef.current?.broadcastGameState({ phase: 'PLAYING' });
+    },
+    joinGame: async (
+      playerId: PlayerId,
+      playerData: Partial<GameState['players'][PlayerId]>,
+    ) => {
+      dispatch({ type: 'JOIN_GAME', payload: { playerId, playerData } });
+      await GameDatabase.addPlayer(playerId, state.gameId, {
+        name: playerData.name || '',
+        flag: playerData.flag,
+        club: playerData.club,
+        role: playerId,
+      });
+      await gameSyncRef.current?.broadcastPlayerJoin(playerId, playerData);
+    },
+    updateHostName: async (name: string) => {
+      dispatch({ type: 'UPDATE_HOST_NAME', payload: { hostName: name } });
+      await GameDatabase.updateGame(state.gameId, { host_name: name });
+      await gameSyncRef.current?.broadcastHostUpdate(name);
+    },
+    updateSegmentSettings: async (settings: Record<SegmentCode, number>) => {
+      dispatch({ type: 'UPDATE_SEGMENT_SETTINGS', payload: { settings } });
+      await GameDatabase.updateGame(state.gameId, {
+        segment_settings: settings,
+      });
+      await gameSyncRef.current?.broadcastGameState({
+        segment_settings: settings,
+      });
+    },
+    createVideoRoom,
+    endVideoRoom,
+    generateDailyToken,
+    trackPresence: (participantData: {
+      id: string;
+      name: string;
+      type: 'host-pc' | 'host-mobile' | 'player';
+      playerId?: PlayerId;
+      flag?: string;
+      club?: string;
+    }) => {
+      void gameSyncRef.current?.trackPresence(participantData);
+    },
+    nextQuestion: async () => {
+      dispatch({ type: 'NEXT_QUESTION' });
+      await GameDatabase.updateGame(state.gameId, {
+        current_question_index: state.currentQuestionIndex + 1,
+      });
+      await gameSyncRef.current?.broadcastGameState({
+        current_question_index: state.currentQuestionIndex + 1,
+      });
+    },
+    nextSegment: async () => {
+      dispatch({ type: 'NEXT_SEGMENT' });
+      const order: SegmentCode[] = ['WSHA', 'AUCT', 'BELL', 'SING', 'REMO'];
+      const idx = state.currentSegment
+        ? order.indexOf(state.currentSegment) + 1
+        : 0;
+      const next = idx < order.length ? order[idx] : null;
+      dispatch({ type: 'SET_CURRENT_SEGMENT', segment: next });
+      await GameDatabase.updateGame(state.gameId, {
+        current_segment: next,
+        current_question_index: 0,
+      });
+      await gameSyncRef.current?.broadcastGameState({
+        current_segment: next,
+        current_question_index: 0,
+      });
+    },
+    updateScore: async (playerId: PlayerId, points: number) => {
+      dispatch({ type: 'UPDATE_SCORE', payload: { playerId, points } });
+      const newScore = state.players[playerId].score + points;
+      await GameDatabase.updatePlayer(playerId, { score: newScore });
+      await gameSyncRef.current?.broadcastGameState({
+        players: { [playerId]: { score: newScore } },
+      });
+    },
+    addStrike: async (playerId: PlayerId) => {
+      dispatch({ type: 'ADD_STRIKE', payload: { playerId } });
+      const strikes = (state.players[playerId].strikes || 0) + 1;
+      await GameDatabase.updatePlayer(playerId, { strikes });
+      await gameSyncRef.current?.broadcastGameState({
+        players: { [playerId]: { strikes } },
+      });
+    },
+    useSpecialButton: async (
+      playerId: PlayerId,
+      buttonType: keyof GameState['players'][PlayerId]['specialButtons'],
+    ) => {
+      dispatch({
+        type: 'USE_SPECIAL_BUTTON',
+        payload: { playerId, buttonType },
+      });
+      const buttons = {
+        ...state.players[playerId].specialButtons,
+        [buttonType]: false,
+      };
+      await GameDatabase.updatePlayer(playerId, { special_buttons: buttons });
+      await gameSyncRef.current?.broadcastGameState({
+        players: { [playerId]: { specialButtons: buttons } },
+      });
+    },
+    startTimer: async (duration: number) => {
+      dispatch({ type: 'START_TIMER', payload: { duration } });
+      await GameDatabase.updateGame(state.gameId, {
+        timer: duration,
+        is_timer_running: true,
+      });
+      await gameSyncRef.current?.broadcastGameState({
+        timer: duration,
+        isTimerRunning: true,
+      });
+    },
+    stopTimer: async () => {
+      dispatch({ type: 'STOP_TIMER' });
+      await GameDatabase.updateGame(state.gameId, {
+        timer: 0,
+        is_timer_running: false,
+      });
+      await gameSyncRef.current?.broadcastGameState({
+        timer: 0,
+        isTimerRunning: false,
+      });
+    },
+    tickTimer: () => {
+      dispatch({ type: 'TICK_TIMER' });
+      void gameSyncRef.current?.broadcastGameState({ timer: state.timer - 1 });
+    },
+    resetGame: async () => {
+      dispatch({ type: 'RESET_GAME' });
+      await GameDatabase.updateGame(state.gameId, {
+        phase: 'CONFIG',
+        current_segment: null,
+        current_question_index: 0,
+        timer: 0,
+        is_timer_running: false,
+      });
+      await gameSyncRef.current?.broadcastGameState({ phase: 'CONFIG' });
+    },
+  };
   return {
     state,
     dispatch,

--- a/src/context/gameReducer.ts
+++ b/src/context/gameReducer.ts
@@ -6,13 +6,15 @@ import type {
   Player,
   PlayerId,
   ScoreEvent,
+  GameAction as SpecAction,
 } from '@/types/game';
+import { initialGameState } from './initialGameState';
 
 export type GameAction =
+  | SpecAction
   | { type: 'INIT'; payload: GameState }
   | { type: 'SET_PHASE'; phase: GamePhase }
   | { type: 'SET_CURRENT_SEGMENT'; segment: SegmentCode | null }
-  | { type: 'ADVANCE_QUESTION' }
   | { type: 'ADD_PLAYER'; player: Player }
   | { type: 'UPDATE_PLAYER'; id: PlayerId; partial: Partial<Player> }
   | { type: 'UPDATE_TIMER'; timer: number; isRunning: boolean }
@@ -38,8 +40,16 @@ export function gameReducer(state: GameState, action: GameAction) {
         draft.isTimerRunning = false;
         return;
 
-      case 'ADVANCE_QUESTION':
+      case 'NEXT_QUESTION':
         draft.currentQuestionIndex += 1;
+        draft.timer = 0;
+        draft.isTimerRunning = false;
+        Object.values(draft.players).forEach((p) => {
+          p.strikes = 0;
+        });
+        return;
+      case 'NEXT_SEGMENT':
+        draft.currentQuestionIndex = 0;
         draft.timer = 0;
         draft.isTimerRunning = false;
         Object.values(draft.players).forEach((p) => {
@@ -54,6 +64,41 @@ export function gameReducer(state: GameState, action: GameAction) {
       case 'UPDATE_PLAYER':
         Object.assign(draft.players[action.id], action.partial);
         return;
+
+      case 'UPDATE_SCORE': {
+        const player = draft.players[action.payload.playerId];
+        player.score += action.payload.points;
+        return;
+      }
+
+      case 'ADD_STRIKE': {
+        const player = draft.players[action.payload.playerId];
+        player.strikes = (player.strikes || 0) + 1;
+        return;
+      }
+
+      case 'USE_SPECIAL_BUTTON': {
+        const player = draft.players[action.payload.playerId];
+        player.specialButtons[action.payload.buttonType] = false;
+        return;
+      }
+
+      case 'START_TIMER':
+        draft.timer = action.payload.duration;
+        draft.isTimerRunning = true;
+        return;
+
+      case 'STOP_TIMER':
+        draft.timer = 0;
+        draft.isTimerRunning = false;
+        return;
+
+      case 'TICK_TIMER':
+        if (draft.timer > 0) draft.timer -= 1;
+        return;
+
+      case 'RESET_GAME':
+        return { ...initialGameState } as GameState;
 
       case 'UPDATE_TIMER':
         draft.timer = action.timer;

--- a/src/pages/FinalScores.tsx
+++ b/src/pages/FinalScores.tsx
@@ -1,3 +1,17 @@
+import Scoreboard from '@/components/Scoreboard';
+import { useGame } from '@/hooks/useGame';
+
 export default function FinalScores() {
-  return null;
+  const { state } = useGame();
+
+  if (state.phase !== 'COMPLETED') return null;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 p-4">
+      <h1 className="text-3xl text-white font-bold mb-6 font-arabic">
+        النتائج النهائية
+      </h1>
+      <Scoreboard />
+    </div>
+  );
 }

--- a/src/pages/SegmentIntro.tsx
+++ b/src/pages/SegmentIntro.tsx
@@ -1,3 +1,18 @@
+import { useGame } from '@/hooks/useGame';
+
 export default function SegmentIntro() {
-  return <div className="p">Segment Intro Page</div>;
+  const { state } = useGame();
+
+  if (!state.currentSegment) return null;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-[#10102a] to-blue-900 p-4">
+      <div className="text-center text-white space-y-4">
+        <h1 className="text-4xl font-bold font-arabic">
+          {state.currentSegment}
+        </h1>
+        <p className="text-white/70 font-arabic">استعد لبدء الفقرة</p>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a complete actions object in `GameContext`
- extend reducer to support scoring, strikes, timers
- embed video only when room url exists
- flesh out SegmentIntro and FinalScores pages
- use query params in Join page

## Testing
- `npx prettier --write src/context/gameReducer.ts src/context/GameContext.tsx src/components/VideoRoom.tsx src/pages/SegmentIntro.tsx src/pages/FinalScores.tsx src/pages/Join.tsx PROJECT_OVERVIEW.md`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3f114b5083309af1b3c63e5e3be9