### PR TITLE
feat: enable local camera after joining video room

### DIFF
--- a/full-dependency-map.json
+++ b/full-dependency-map.json
@@ -32,7 +32,9 @@
   "src/components/LazyImage.tsx": [],
   "src/components/Scoreboard.tsx": [],
   "src/components/Timer.tsx": [],
-  "src/components/VideoRoom.tsx": [],
+  "src/components/VideoRoom.tsx": [
+    "src/components/AlertBanner.tsx"
+  ],
   "src/context/GameContext.tsx": [
     "src/context/defaults.ts",
     "src/context/gameReducer.ts",

--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import {
   useDaily,
   useParticipantIds,
@@ -7,6 +7,7 @@ import {
 } from '@daily-co/daily-react';
 import DailyIframe, { type DailyCall } from '@daily-co/daily-js';
 import { useGameState, useGameActions } from '@/hooks/useGameAtoms';
+import AlertBanner from './AlertBanner';
 
 interface VideoRoomProps {
   gameId: string;
@@ -27,11 +28,13 @@ function ParticipantVideo({ participantId }: ParticipantVideoProps) {
   useEffect(() => {
     if (participant?.tracks.video.persistentTrack && videoRef.current) {
       const videoElement = videoRef.current;
-      const stream = new MediaStream([participant.tracks.video.persistentTrack]);
+      const stream = new MediaStream([
+        participant.tracks.video.persistentTrack,
+      ]);
       videoElement.srcObject = stream;
       videoElement.autoplay = true;
       videoElement.playsInline = true;
-      
+
       // Mute local user video to prevent echo
       if (participant.local) {
         videoElement.muted = true;
@@ -41,9 +44,15 @@ function ParticipantVideo({ participantId }: ParticipantVideoProps) {
 
   // Set up audio stream using MediaStreamTrack
   useEffect(() => {
-    if (participant?.tracks.audio.persistentTrack && audioRef.current && !participant.local) {
+    if (
+      participant?.tracks.audio.persistentTrack &&
+      audioRef.current &&
+      !participant.local
+    ) {
       const audioElement = audioRef.current;
-      const stream = new MediaStream([participant.tracks.audio.persistentTrack]);
+      const stream = new MediaStream([
+        participant.tracks.audio.persistentTrack,
+      ]);
       audioElement.srcObject = stream;
       audioElement.autoplay = true;
     }
@@ -53,8 +62,12 @@ function ParticipantVideo({ participantId }: ParticipantVideoProps) {
     return null;
   }
 
-  const hasVideo = participant.tracks.video.state === 'playable' || participant.tracks.video.state === 'sendable';
-  const hasAudio = participant.tracks.audio.state === 'playable' || participant.tracks.audio.state === 'sendable';
+  const hasVideo =
+    participant.tracks.video.state === 'playable' ||
+    participant.tracks.video.state === 'sendable';
+  const hasAudio =
+    participant.tracks.audio.state === 'playable' ||
+    participant.tracks.audio.state === 'sendable';
 
   return (
     <div className="flex-1 min-w-0 bg-gray-800 rounded-lg overflow-hidden relative">
@@ -78,33 +91,28 @@ function ParticipantVideo({ participantId }: ParticipantVideoProps) {
             </div>
           </div>
         )}
-        
+
         {/* Audio element (hidden, for non-local participants) */}
-        {!participant.local && (
-          <audio
-            ref={audioRef}
-            autoPlay
-          />
-        )}
+        {!participant.local && <audio ref={audioRef} autoPlay />}
 
         {/* Status indicators */}
         <div className="absolute bottom-2 right-2 flex gap-1">
-          <div className={`w-6 h-6 rounded flex items-center justify-center ${
-            hasAudio ? 'bg-green-600' : 'bg-red-600'
-          }`}>
-            <span className="text-white text-xs">
-              {hasAudio ? '🎤' : '🚫'}
-            </span>
+          <div
+            className={`w-6 h-6 rounded flex items-center justify-center ${
+              hasAudio ? 'bg-green-600' : 'bg-red-600'
+            }`}
+          >
+            <span className="text-white text-xs">{hasAudio ? '🎤' : '🚫'}</span>
           </div>
-          <div className={`w-6 h-6 rounded flex items-center justify-center ${
-            hasVideo ? 'bg-green-600' : 'bg-red-600'
-          }`}>
-            <span className="text-white text-xs">
-              {hasVideo ? '📷' : '🚫'}
-            </span>
+          <div
+            className={`w-6 h-6 rounded flex items-center justify-center ${
+              hasVideo ? 'bg-green-600' : 'bg-red-600'
+            }`}
+          >
+            <span className="text-white text-xs">{hasVideo ? '📷' : '🚫'}</span>
           </div>
         </div>
-        
+
         {/* Participant name overlay */}
         <div className="absolute bottom-2 left-2 bg-black/70 text-white px-2 py-1 rounded text-sm">
           {participant.user_name || participantId}
@@ -115,44 +123,50 @@ function ParticipantVideo({ participantId }: ParticipantVideoProps) {
   );
 }
 
-function VideoRoomContent({ gameId, className = '', observerMode = false }: VideoRoomProps) {
+function VideoRoomContent({
+  gameId,
+  className = '',
+  observerMode = false,
+}: VideoRoomProps) {
   const daily = useDaily();
   const participantIds = useParticipantIds();
   const state = useGameState();
   const { generateDailyToken } = useGameActions();
+  // Track join or permission errors to surface to the user via an alert banner
+  const [joinError, setJoinError] = useState<string | null>(null);
 
   // Get user info from URL parameters
   const getUserInfo = useCallback(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const role = urlParams.get('role');
     const name = urlParams.get('name') || 'User';
-    
+
     if (observerMode) {
       return {
         userName: state.hostName || name,
         isHost: true,
-        isObserver: true
+        isObserver: true,
       };
     }
-    
+
     if (role === 'host' || role === 'host-mobile') {
       return {
         userName: state.hostName || name,
         isHost: true,
-        isObserver: false
+        isObserver: false,
       };
     } else if (role === 'playerA' || role === 'playerB') {
       return {
         userName: name,
         isHost: false,
-        isObserver: false
+        isObserver: false,
       };
     }
-    
+
     return {
       userName: name,
       isHost: false,
-      isObserver: false
+      isObserver: false,
     };
   }, [state.hostName, observerMode]);
 
@@ -170,7 +184,7 @@ function VideoRoomContent({ gameId, className = '', observerMode = false }: Vide
           gameId,
           userInfo.userName,
           userInfo.isHost,
-          userInfo.isObserver
+          userInfo.isObserver,
         );
 
         if (!token) {
@@ -181,12 +195,23 @@ function VideoRoomContent({ gameId, className = '', observerMode = false }: Vide
         await daily.join({
           url: state.videoRoomUrl,
           token: token,
-          userName: userInfo.userName
+          userName: userInfo.userName,
         });
+
+        // Attempt to enable the local user's camera and surface permission errors
+        try {
+          await daily.setLocalVideo(true);
+        } catch (cameraError) {
+          console.error('[VideoRoom] Camera permission error:', cameraError);
+          setJoinError(
+            'Unable to access your camera. Please allow camera permissions and refresh.',
+          );
+        }
 
         console.log('[VideoRoom] Successfully joined the call');
       } catch (error) {
         console.error('[VideoRoom] Failed to join call:', error);
+        setJoinError('Failed to join the video call. Please try again.');
       }
     };
 
@@ -204,7 +229,9 @@ function VideoRoomContent({ gameId, className = '', observerMode = false }: Vide
 
   if (!state.videoRoomCreated || !state.videoRoomUrl) {
     return (
-      <div className={`bg-gray-500/20 border border-gray-500/30 rounded-xl p-6 ${className}`}>
+      <div
+        className={`bg-gray-500/20 border border-gray-500/30 rounded-xl p-6 ${className}`}
+      >
         <div className="text-center">
           <div className="text-gray-400 text-lg font-bold mb-2">
             Video room not available
@@ -219,24 +246,34 @@ function VideoRoomContent({ gameId, className = '', observerMode = false }: Vide
 
   return (
     <div className={`${className}`}>
+      {/* Display any join or permission errors to the user */}
+      {joinError && (
+        <AlertBanner
+          message={joinError}
+          type="error"
+          isVisible={Boolean(joinError)}
+          onClose={() => setJoinError(null)}
+        />
+      )}
+
       <div className="bg-gray-800/50 rounded-xl p-4 border border-gray-600/30">
         <h3 className="text-lg font-bold text-white mb-4 text-center">
           Live Video Room
         </h3>
-        
+
         {/* Horizontal participant layout with dividers */}
         <div className="flex gap-4 min-h-[200px]">
           {participantIds.map((participantId, index) => (
             <div key={participantId} className="flex items-stretch">
               <ParticipantVideo participantId={participantId} />
-              
+
               {/* Divider between participants (not after the last one) */}
               {index < participantIds.length - 1 && (
                 <div className="w-px bg-gray-600 mx-2 self-stretch" />
               )}
             </div>
           ))}
-          
+
           {/* Show message if no participants */}
           {participantIds.length === 0 && (
             <div className="flex-1 flex items-center justify-center">
@@ -251,7 +288,7 @@ function VideoRoomContent({ gameId, className = '', observerMode = false }: Vide
             </div>
           )}
         </div>
-        
+
         {/* Info note */}
         <div className="mt-4 bg-blue-500/10 rounded-lg p-3 border border-blue-500/20">
           <p className="text-blue-300 text-sm text-center">
@@ -277,8 +314,8 @@ export default function VideoRoom(props: VideoRoomProps) {
       return DailyIframe.createCallObject();
     } catch (error) {
       console.warn('[VideoRoom] Failed to create Daily call object:', error);
-      // Return a mock object that won't cause issues
-      return null as any;
+      // Return a typed mock to avoid runtime issues while satisfying TypeScript
+      return null as unknown as DailyCall;
     }
   }, []);
 
@@ -292,10 +329,10 @@ export default function VideoRoom(props: VideoRoomProps) {
           const meetingState = callObject.meetingState();
           // Only destroy if not in a state that doesn't require cleanup
           if (
-            meetingState !== "left-meeting" &&
-            meetingState !== "error" &&
-            meetingState !== "new" &&
-            meetingState !== "loading"
+            meetingState !== 'left-meeting' &&
+            meetingState !== 'error' &&
+            meetingState !== 'new' &&
+            meetingState !== 'loading'
           ) {
             callObject.destroy();
           }
@@ -309,13 +346,17 @@ export default function VideoRoom(props: VideoRoomProps) {
   // Only render if video room is created and call object is available
   if (!state.videoRoomCreated || !state.videoRoomUrl || !callObject) {
     return (
-      <div className={`bg-gray-500/20 border border-gray-500/30 rounded-xl p-6 ${props.className || ''}`}>
+      <div
+        className={`bg-gray-500/20 border border-gray-500/30 rounded-xl p-6 ${props.className || ''}`}
+      >
         <div className="text-center">
           <div className="text-gray-400 text-lg font-bold mb-2">
             Video room not available
           </div>
           <div className="text-gray-300 text-sm">
-            {!callObject ? 'Daily.co initialization failed' : 'Waiting for video room creation...'}
+            {!callObject
+              ? 'Daily.co initialization failed'
+              : 'Waiting for video room creation...'}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- enable local camera after joining Daily call
- show banner errors when camera permissions are denied or join fails
- remove explicit `any` cast from call object fallback

## Testing
- `npx prettier src/components/VideoRoom.tsx --write`
- `pnpm lint`
- `pnpm tsc --noEmit`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688e6b2b450483309f299bc9b0bbb981