### PR TITLE
chore: remove netlify error monitoring plugin

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,6 @@ This repository is configured to work with Model Context Protocol (MCP) servers 
 - **Sequential Thinking**: Advanced problem-solving and planning
 - **Memory**: Knowledge graph for project context
 - **Playwright**: Web automation and testing
-- **Sentry**: Error monitoring and debugging
 - **Firecrawl**: Web scraping and content extraction
 - **ImageSorcery**: Image processing and manipulation
 

--- a/.github/copilot-web-mcp.json
+++ b/.github/copilot-web-mcp.json
@@ -41,11 +41,6 @@
         "FIRECRAWL_API_KEY": "$COPILOT_MCP_FIRECRAWL_API_KEY"
       },
       "tools": ["*"]
-    },
-    "sentry": {
-      "type": "sse",
-      "url": "https://mcp.sentry.dev/mcp",
-      "tools": ["*"]
     }
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,17 @@
 
 ---
 
-## Latest - 2025-01-23
+## Latest - 2025-08-21
+
+### 🗑️ Removed - Netlify error monitoring plugin references
+
+- Cleared MCP configuration and documentation tied to the deprecated Netlify error monitoring plugin.
+- **Files Modified**:
+  - `.github/copilot-instructions.md`
+  - `.github/copilot-web-mcp.json`
+  - `docs/GITHUB_COPILOT_MCP_SETUP.md`
+
+## Previous - 2025-01-23
 
 ### 🛡️ Added - Comprehensive Supabase Database Security & Performance Overhaul
 
@@ -49,7 +59,7 @@
 - **Purpose**: Address all TODOs from supabase.md with production-ready security and performance
 - **Status**: ✅ All Supabase TODOs completed successfully
 
-## Previous - 2025-08-21
+## Earlier - 2025-08-21
 
 ### ✨ Added - User Flow State Diagrams
 

--- a/docs/GITHUB_COPILOT_MCP_SETUP.md
+++ b/docs/GITHUB_COPILOT_MCP_SETUP.md
@@ -14,7 +14,6 @@ GitHub Copilot Web supports MCP servers to extend its capabilities with external
 4. **Playwright** - Web automation and testing
 5. **ImageSorcery** - Image processing and manipulation
 6. **Firecrawl** - Web scraping and content extraction (requires API key)
-7. **Sentry** - Error monitoring and debugging
 
 ## Setup Instructions
 
@@ -67,11 +66,6 @@ GitHub Copilot Web supports MCP servers to extend its capabilities with external
       "env": {
         "FIRECRAWL_API_KEY": "$COPILOT_MCP_FIRECRAWL_API_KEY"
       },
-      "tools": ["*"]
-    },
-    "sentry": {
-      "type": "sse",
-      "url": "https://mcp.sentry.dev/mcp",
       "tools": ["*"]
     }
   }
@@ -171,12 +165,6 @@ For Firecrawl MCP server:
 
 - **Purpose**: Web scraping and content extraction
 - **API Key Required**: Sign up at https://www.firecrawl.dev/
-
-### Sentry
-
-- **Purpose**: Error monitoring and debugging integration
-- **Type**: Server-Sent Events (SSE) connection
-- **No API Key Required** for basic functionality
 
 ## Best Practices
 

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -39,6 +39,10 @@ Sections
 
 - Theme system: persist custom colors and apply them globally (write CSS vars from `customColorsAtom`)
 
+## Monitoring
+
+- Evaluate alternative error monitoring after removing the previous Netlify plugin — 2025-08-21
+
 - Color picker: add background/surface pickers and live preview
   - Note: partial implementation added for primary/secondary/accent pickers; background/surface and persistence remain TODO — 2025-08-21
 


### PR DESCRIPTION
## Summary
- strip remaining references to the removed Netlify error monitoring plugin
- document cleanup in changelog and TODOs

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`
- `pnpm test`
- `node scripts/bundle-guard.mjs` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aa8a94a4833088e44d003a2a15bd